### PR TITLE
Optional import of org.apache.naming.factory

### DIFF
--- a/src/main/webapp/WEB-INF/liferay-plugin-package.properties
+++ b/src/main/webapp/WEB-INF/liferay-plugin-package.properties
@@ -19,3 +19,5 @@ liferay-versions=6.1+,6.2.0+,6.2.10+,7.0.0+,7.1.0+,7.2.0+,7.3.0+
 #security-manager-files-delete=../temp/-
 
 # but others permission are impossible to have (reflect, management, etc...)
+
+Import-Package: org.apache.naming.factory;resolution:="optional"


### PR DESCRIPTION
Added `org.apache.naming.factory` as an optional import to `Import-Package`

Allows JDBC monitoring in Tomcat in an OSGi environment (Liferay 7+). Probably, for other application servers, another package has to be imported.

The class `org.apache.naming.factory.ResourceLinkFactory` is loaded via reflection to obtain the DataSource registered in JNDI.

In order for this to work, the Portal Property `module.framework.system.packages.extra` must be modified to contain the package `org.apache.naming.factory`